### PR TITLE
fix(package): declare dsh chat participant to stop activation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,13 @@
     ],
     "main": "./dist/extension.js",
     "types": "./dist/extension.d.ts",
+    "chatParticipants": [
+        {
+            "id": "dsh",
+            "name": "DSH",
+            "description": "Send a task to the DeepSeek Harness session"
+        }
+    ],
     "activationEvents": [
         "onStartupFinished",
         "onView:dsh.chatView",


### PR DESCRIPTION
## Summary

Follow-up to #3 (the session-store CPU burn is already handled by `4522803 perf: 提高缓存性能，#3` on main).

This PR fixes the **secondary activation error** reported in #3: the extension calls `vscode.chat.createChatParticipant("dsh")` (src/extension.ts) but `package.json` has no `chatParticipants` declaration, so the host logs `chatParticipant must be declared in package.json: dsh` on every activation.

## Change

- Declare the `dsh` chat participant in package.json.

## Verification

- `npm test` passes (57/57).