### PR TITLE
feat(webview): 思维链流式输出时自动展开、结束后自动收起

### DIFF
--- a/package.json
+++ b/package.json
@@ -608,6 +608,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "%config.enableEffortKnob.description%"
+                },
+                "dsh.autoOpenReasoning": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%config.autoOpenReasoning.description%"
                 }
             }
         }

--- a/package.nls.json
+++ b/package.nls.json
@@ -61,5 +61,6 @@
     "config.agentStatusLabel.description": "Optional fixed text shown while DSH is streaming an assistant response. Leave empty to randomly choose an item from dsh.agentStatusLabels. A companion extension can temporarily override either setting through the exported API.",
     "config.agentStatusLabels.description": "Candidate labels randomly selected once per streaming agent turn when dsh.agentStatusLabel is empty.",
     "config.balanceRefreshIntervalMs.description": "Interval for refreshing the DeepSeek balance status bar item.",
-    "config.enableEffortKnob.description": "Show the chibi runner sprite as the reasoning effort slider knob. Disable to use the native slider handle."
+    "config.enableEffortKnob.description": "Show the chibi runner sprite as the reasoning effort slider knob. Disable to use the native slider handle.",
+    "config.autoOpenReasoning.description": "Automatically expand the reasoning fold while it is streaming in and collapse it when streaming completes. Manual toggles between those transitions are respected; history messages stay collapsed."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -61,5 +61,6 @@
     "config.agentStatusLabel.description": "DSH 流式输出助手回复时显示的固定文字。留空时会从 dsh.agentStatusLabels 中随机选择；配套扩展可通过导出的 API 临时覆盖这两项设置。",
     "config.agentStatusLabels.description": "当 dsh.agentStatusLabel 为空时，每轮流式 Agent 回复开始时随机选择一次的候选文案。",
     "config.balanceRefreshIntervalMs.description": "DeepSeek 余额状态栏项目的刷新间隔。",
-    "config.enableEffortKnob.description": "在思考强度滑块上用大肥鱼（chibi runner）精灵图作为滑块按钮。关闭后使用原生滑块手柄。"
+    "config.enableEffortKnob.description": "在思考强度滑块上用大肥鱼（chibi runner）精灵图作为滑块按钮。关闭后使用原生滑块手柄。",
+    "config.autoOpenReasoning.description": "思维链流式输出时自动展开折叠块，流式结束后自动收起。两个时机之间仍可手动开合；历史消息保持收起。"
 }

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -451,7 +451,10 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             vscode.window.onDidChangeTextEditorSelection(() => this.schedulePostState()),
             this.changeReviews.onDidUpdate(() => this.schedulePostState()),
             vscode.workspace.onDidChangeConfiguration((event) => {
-                if (event.affectsConfiguration("dsh.enableEffortKnob")) {
+                if (
+                    event.affectsConfiguration("dsh.enableEffortKnob") ||
+                    event.affectsConfiguration("dsh.autoOpenReasoning")
+                ) {
                     this.schedulePostState();
                 }
             }),
@@ -2863,6 +2866,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         const host = presentHostBaseline(this.runtime.getHostDescription());
         const busy = selected?.running === true;
         const agentStatusLabel = this.agentStatusLabel(this.sessionId, busy);
+        const autoOpenReasoning =
+            vscode.workspace.getConfiguration("dsh").get<boolean>("autoOpenReasoning", true);
         const projectedMessages = focusChatMessages(
             projectChatMessages(session, this.optimisticPrompts, this.sessionSkillNames()),
             this.focusMode,
@@ -2894,6 +2899,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             ...(agentStatusLabel === undefined
                 ? {}
                 : { agentStatusLabel }),
+            ...(autoOpenReasoning ? {} : { autoOpenReasoning: false }),
             submitting: this.submitting,
             cancelling: this.cancelRequested && selected?.running === true,
             focusMode: this.focusMode,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1149,6 +1149,8 @@ export interface ChatViewState {
     busy: boolean;
     /** Plugin-provided label for the current streaming assistant state. */
     agentStatusLabel?: string;
+    /** False disables auto open/close of the reasoning fold around streaming. */
+    autoOpenReasoning?: boolean;
     submitting: boolean;
     cancelling: boolean;
     focusMode: boolean;

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -29,6 +29,7 @@ export function App(): React.JSX.Element {
                 messages={state.messages}
                 submitting={state.submitting}
                 agentStatusLabel={state.agentStatusLabel}
+                autoOpenReasoning={state.autoOpenReasoning}
             />
             {!state.focusMode ? <Interactions interactions={state.interactions} /> : null}
             {!state.focusMode ? (

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -48,6 +48,7 @@ export function App(): React.JSX.Element {
                     sessionId={state.sessionId}
                     sessionRunning={state.sessionStatus?.running === true}
                     agentPresetLabel={state.agentPresetLabel}
+                    autoOpenReasoning={state.autoOpenReasoning}
                 />
             ) : null}
             <Composer

--- a/webview/src/components/MessageContent.tsx
+++ b/webview/src/components/MessageContent.tsx
@@ -19,9 +19,14 @@ function ReasoningFold({
     autoOpen: boolean;
 }): React.JSX.Element {
     const detailsRef = useRef<HTMLDetailsElement>(null);
+    const previousStreamingRef = useRef<boolean>();
     const streaming = message.reasoningState === "streaming";
     useEffect(() => {
-        if (!autoOpen || !detailsRef.current) return;
+        // Write `open` only on a streaming transition, so a setting toggle
+        // without a transition never overrides the user's manual collapsed state.
+        const previousStreaming = previousStreamingRef.current;
+        previousStreamingRef.current = streaming;
+        if (!autoOpen || previousStreaming === streaming || !detailsRef.current) return;
         detailsRef.current.open = streaming;
     }, [autoOpen, streaming]);
     const reasoningBody = (

--- a/webview/src/components/MessageContent.tsx
+++ b/webview/src/components/MessageContent.tsx
@@ -1,8 +1,54 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import type { ChatMessage } from "../../../src/types";
 import { t } from "../i18n";
 import { CompactionCard, ToolCard } from "./Cards";
 import { MessageImages } from "./MessageImages";
+
+/**
+ * The reasoning fold auto-expands while reasoning streams in and auto-collapses
+ * when streaming completes. The effect only writes `open` when `streaming`
+ * flips, so manual toggling between the two transitions is never overridden.
+ */
+function ReasoningFold({
+    message,
+    agentStatusLabel,
+    autoOpen,
+}: {
+    message: ChatMessage;
+    agentStatusLabel?: string;
+    autoOpen: boolean;
+}): React.JSX.Element {
+    const detailsRef = useRef<HTMLDetailsElement>(null);
+    const streaming = message.reasoningState === "streaming";
+    useEffect(() => {
+        if (!autoOpen || !detailsRef.current) return;
+        detailsRef.current.open = streaming;
+    }, [autoOpen, streaming]);
+    const reasoningBody = (
+        <div
+            className="dsh-message-body"
+            {...(typeof message.renderedReasoningHtml === "string"
+                ? { dangerouslySetInnerHTML: { __html: message.renderedReasoningHtml } }
+                : { children: <p>{message.reasoning}</p> })}
+        />
+    );
+    return (
+        <details
+            ref={detailsRef}
+            className="dsh-message-reasoning"
+            {...(typeof message.reasoningRenderId === "string"
+                ? { "data-render-id": message.reasoningRenderId }
+                : {})}
+        >
+            <summary>
+                {streaming
+                    ? agentStatusLabel ?? t("Thinking...")
+                    : t("Reasoning · complete")}
+            </summary>
+            {reasoningBody}
+        </details>
+    );
+}
 
 /**
  * Body + optional reasoning fold. `renderedHtml` is fixed-vocabulary HTML produced
@@ -11,9 +57,11 @@ import { MessageImages } from "./MessageImages";
 export function MessageContent({
     message,
     agentStatusLabel,
+    autoOpenReasoning,
 }: {
     message: ChatMessage;
     agentStatusLabel?: string;
+    autoOpenReasoning?: boolean;
 }): React.JSX.Element {
     if (message.role === "tool" && message.tool) {
         return <ToolCard tool={message.tool} />;
@@ -40,31 +88,15 @@ export function MessageContent({
     if (message.role !== "assistant" || !message.reasoning) {
         return <>{images}{skill}{body}</>;
     }
-    const reasoningBody = (
-        <div
-            className="dsh-message-body"
-            {...(typeof message.renderedReasoningHtml === "string"
-                ? { dangerouslySetInnerHTML: { __html: message.renderedReasoningHtml } }
-                : { children: <p>{message.reasoning}</p> })}
-        />
-    );
     return (
         <>
             {images}
             {body}
-            <details
-                className="dsh-message-reasoning"
-                {...(typeof message.reasoningRenderId === "string"
-                    ? { "data-render-id": message.reasoningRenderId }
-                    : {})}
-            >
-                <summary>
-                    {message.reasoningState === "streaming"
-                        ? agentStatusLabel ?? t("Thinking...")
-                        : t("Reasoning · complete")}
-                </summary>
-                {reasoningBody}
-            </details>
+            <ReasoningFold
+                message={message}
+                agentStatusLabel={agentStatusLabel}
+                autoOpen={autoOpenReasoning !== false}
+            />
         </>
     );
 }

--- a/webview/src/components/MessageContent.tsx
+++ b/webview/src/components/MessageContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useLayoutEffect, useRef } from "react";
 import type { ChatMessage } from "../../../src/types";
 import { t } from "../i18n";
 import { CompactionCard, ToolCard } from "./Cards";
@@ -21,7 +21,8 @@ function ReasoningFold({
     const detailsRef = useRef<HTMLDetailsElement>(null);
     const previousStreamingRef = useRef<boolean>();
     const streaming = message.reasoningState === "streaming";
-    useEffect(() => {
+    useLayoutEffect(() => {
+        // Update the fold before MessageList's layout effect measures the scroll height.
         // Write `open` only on a streaming transition, so a setting toggle
         // without a transition never overrides the user's manual collapsed state.
         const previousStreaming = previousStreamingRef.current;

--- a/webview/src/components/MessageItem.tsx
+++ b/webview/src/components/MessageItem.tsx
@@ -12,6 +12,7 @@ interface MessageItemProps {
     message: ChatMessage;
     submitting: boolean;
     agentStatusLabel?: string;
+    autoOpenReasoning?: boolean;
 }
 
 type CheckpointAction =
@@ -82,6 +83,7 @@ export const MessageItem = React.memo(function MessageItem({
     message,
     submitting,
     agentStatusLabel,
+    autoOpenReasoning,
 }: MessageItemProps): React.JSX.Element {
     const stateClass =
         message.state === "streaming"
@@ -130,7 +132,11 @@ export const MessageItem = React.memo(function MessageItem({
                 ) : null}
                 {checkpointSeq === undefined ? null : <MessageCheckpointMenu seq={checkpointSeq} />}
             </div>
-            <MessageContent message={message} agentStatusLabel={agentStatusLabel} />
+            <MessageContent
+                message={message}
+                agentStatusLabel={agentStatusLabel}
+                autoOpenReasoning={autoOpenReasoning}
+            />
             {message.state === "failed" ? (
                 <button
                     type="button"

--- a/webview/src/components/MessageList.tsx
+++ b/webview/src/components/MessageList.tsx
@@ -9,6 +9,7 @@ interface MessageListProps {
     messages: ChatMessage[];
     submitting: boolean;
     agentStatusLabel?: string;
+    autoOpenReasoning?: boolean;
 }
 
 /** Structural equality for plain host-projected data (no functions, no cycles). */
@@ -64,6 +65,7 @@ export const MessageList = React.memo(function MessageList({
     messages,
     submitting,
     agentStatusLabel,
+    autoOpenReasoning,
 }: MessageListProps): React.JSX.Element {
     const listRef = useRef<HTMLDivElement>(null);
     const stickToBottomRef = useRef(true);
@@ -138,6 +140,7 @@ export const MessageList = React.memo(function MessageList({
                         message={message}
                         submitting={submitting}
                         agentStatusLabel={agentStatusLabel}
+                        autoOpenReasoning={autoOpenReasoning}
                     />
                 ))
             )}

--- a/webview/src/components/dock/ActivityDock.tsx
+++ b/webview/src/components/dock/ActivityDock.tsx
@@ -34,6 +34,7 @@ interface ActivityDockProps {
     sessionId: ActivityDockState["sessionId"];
     sessionRunning: boolean;
     agentPresetLabel: ActivityDockState["agentPresetLabel"];
+    autoOpenReasoning?: boolean;
 }
 
 export const ActivityDock = React.memo(function ActivityDock({
@@ -51,6 +52,7 @@ export const ActivityDock = React.memo(function ActivityDock({
     sessionId,
     sessionRunning,
     agentPresetLabel,
+    autoOpenReasoning,
 }: ActivityDockProps): React.JSX.Element | null {
     const [active, setActive] = useState<DockTab | null>(null);
     const [collapsed, setCollapsed] = useState(true);
@@ -169,7 +171,7 @@ export const ActivityDock = React.memo(function ActivityDock({
                     {!collapsed && selectedTab === "goal" && tab.id === "goal" && goal ? <GoalPanel goal={goal} /> : null}
                     {!collapsed && selectedTab === "queue" && tab.id === "queue" ? <QueuePanel queue={queue} running={sessionRunning} /> : null}
                     {!collapsed && selectedTab === "changes" && tab.id === "changes" ? <ChangesPanel reviews={changeReviews} running={sessionRunning} /> : null}
-                    {!collapsed && selectedTab === "subagents" && tab.id === "subagents" && subagents ? <SubagentsPanel tree={subagents} preview={preview} /> : null}
+                    {!collapsed && selectedTab === "subagents" && tab.id === "subagents" && subagents ? <SubagentsPanel tree={subagents} preview={preview} autoOpenReasoning={autoOpenReasoning} /> : null}
                     {!collapsed && selectedTab === "jobs" && tab.id === "jobs" ? <JobsPanel jobs={jobs} /> : null}
                     {!collapsed && selectedTab === "schedule" && tab.id === "schedule" && schedule ? <SchedulePanel schedule={schedule} /> : null}
                     {!collapsed && selectedTab === "permissions" && tab.id === "permissions" && permissions ? <PermissionsPanel permissions={permissions} switchable={canSwitchPermissions(commands)} /> : null}

--- a/webview/src/components/dock/SubagentsPanel.tsx
+++ b/webview/src/components/dock/SubagentsPanel.tsx
@@ -88,7 +88,7 @@ function formatExactDuration(milliseconds: number): string {
     });
 }
 
-function SubagentPreviewCard({ preview, now }: { preview: SubagentHistoryPreview; now: number }): React.JSX.Element {
+function SubagentPreviewCard({ preview, now, autoOpenReasoning }: { preview: SubagentHistoryPreview; now: number; autoOpenReasoning?: boolean }): React.JSX.Element {
     const [followUp, setFollowUp] = useState("");
     const busy = Boolean(preview.pendingAction);
     const canFollowUp = preview.parentAvailable && !busy;
@@ -126,7 +126,7 @@ function SubagentPreviewCard({ preview, now }: { preview: SubagentHistoryPreview
                             <div className="dsh-message-label">
                                 {message.role === "assistant" ? "subagent" : message.role === "user" ? t("You") : t("System")}
                             </div>
-                            <MessageContent message={message} />
+                            <MessageContent message={message} autoOpenReasoning={autoOpenReasoning} />
                         </div>
                     ))}
                 </div>
@@ -164,7 +164,7 @@ function SubagentPreviewCard({ preview, now }: { preview: SubagentHistoryPreview
     );
 }
 
-export function SubagentsPanel({ tree, preview }: { tree: SubagentTreeView; preview?: SubagentHistoryPreview }): React.JSX.Element {
+export function SubagentsPanel({ tree, preview, autoOpenReasoning }: { tree: SubagentTreeView; preview?: SubagentHistoryPreview; autoOpenReasoning?: boolean }): React.JSX.Element {
     const [now, setNow] = useState(() => Date.now());
     const hasRunningTiming = tree.nodes.some(
         (node) => node.kind === "child" && node.activity === "running" && node.timing?.active !== undefined,
@@ -222,7 +222,7 @@ export function SubagentsPanel({ tree, preview }: { tree: SubagentTreeView; prev
                     </div>
                 );
             })}
-            {preview ? <SubagentPreviewCard preview={preview} now={now} /> : null}
+            {preview ? <SubagentPreviewCard preview={preview} now={now} autoOpenReasoning={autoOpenReasoning} /> : null}
         </div>
     );
 }


### PR DESCRIPTION
## 功能

新增 `dsh.autoOpenReasoning` 设置（默认开启）：助手**思维链流式输出时自动展开**折叠块，**流式结束后自动收起**，无需手动点击。关闭设置后行为与现状完全一致。

## 行为细则

- `reasoningState` 变为 `streaming` 时把 `<details>.open` 置 `true`；流式结束（`streaming → complete`）置 `false`
- effect 仅在 `streaming` 翻转时写入 `open`，两个转换之间手动开合不被后续渲染覆盖
- 历史/已完成消息不自动展开；关闭设置时自动开/收均不干预

## 修改清单（9 文件，+83/−26）

| 文件 | 改动 |
|---|---|
| `package.json` | `contributes.configuration` 新增 `dsh.autoOpenReasoning`（boolean，默认 `true`） |
| `package.nls.json` / `package.nls.zh-cn.json` | 中英文描述（zh-hans 由 sync:locales 派生，不入库） |
| `src/types.ts` | `ChatViewState` 新增 `autoOpenReasoning?: boolean` |
| `src/chatView.ts` | 复用 `enableEffortKnob` 配置监听器；状态构建时读取设置，仅关闭时下发 `autoOpenReasoning: false`（默认值省略的既有载荷风格） |
| `webview/src/App.tsx` / `MessageList.tsx` / `MessageItem.tsx` | 按 `agentStatusLabel` 既有链路逐层透传 |
| `webview/src/components/MessageContent.tsx` | 抽出 `ReasoningFold` 组件：ref + `useEffect`，依赖 `[autoOpen, streaming]`，streaming 翻转时写 `open` |

## 验证

- `npm run check`（host + webview 双 `tsc --noEmit`）✅ 通过
- `npm run compile`（sync:locales + build:webview + tsc）✅ 通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增“自动展开推理内容”设置，默认开启。
  - 推理内容流式生成时自动展开，生成完成后自动折叠。
  - 支持在设置中关闭自动展开行为，历史消息保持折叠状态。
  - 自动切换期间尊重用户手动展开或折叠的操作。
  - 子代理推理内容同样支持上述自动展开与折叠行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->